### PR TITLE
Add fallback data source with caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Este projeto implementa uma API REST completa para predição de preços de Bitc
 ### Características Principais
 
 - **🤖 Modelo LSTM**: Rede neural recorrente para séries temporais
-- **📊 Dados em Tempo Real**: Integração com Yahoo Finance
+- **📊 Dados em Tempo Real**: Integração com Yahoo Finance com cache local e fallback para Stooq
 - **🔍 Monitoramento**: Prometheus + Grafana para observabilidade
 - **🐳 Containerização**: Deploy completo com Docker Compose
 - **📈 Métricas**: Avaliação detalhada do modelo (RMSE, MAE, R²)


### PR DESCRIPTION
## Summary
- add `fetch_bitcoin_data` to cache price data and fall back to Stooq
- use the new helper in training and prediction routes
- document fallback and caching in README
- keep a `data/` directory for cached csv files

## Testing
- `bash pre-build-check.sh`
- `python -m py_compile main.py`
- *(failed to run app due to missing dependencies)*